### PR TITLE
FEAT : 휴가 신청 시 캘린더 제어

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -11,8 +11,15 @@ import {
   getVcReqList,
   getVcReqDetail,
   getMyTeamSchedule,
+  getEntireRemainVcTo,
 } from './vacation-request'
-export { createRequest, getVcReqList, getVcReqDetail, getMyTeamSchedule }
+export {
+  createRequest,
+  getVcReqList,
+  getVcReqDetail,
+  getMyTeamSchedule,
+  getEntireRemainVcTo,
+}
 
 // EMP
 import {

--- a/src/api/vacation-request.js
+++ b/src/api/vacation-request.js
@@ -41,3 +41,11 @@ export const getMyTeamSchedule = () => {
     method: 'get',
   })
 }
+
+/*부서별 잔여 TO (모든 팀원의 휴가들을 날짜별로 to에서 차감)*/
+export const getEntireRemainVcTo = () => {
+  return api({
+    url: '/vacations/remain-to',
+    method: 'get',
+  })
+}

--- a/src/sweetAlert/index.js
+++ b/src/sweetAlert/index.js
@@ -93,7 +93,7 @@ export const loadingAlert = () => {
     allowOutsideClick: false,
     didOpen: () => {
       Swal.showLoading()
-    }
+    },
   })
 }
 

--- a/src/views/calendar/Calendar.vue
+++ b/src/views/calendar/Calendar.vue
@@ -276,12 +276,12 @@ onMounted(async () => {
     console.log('google calendar api called')
 
     const list = res.data.items
-    list.forEach((e) => {
+    list.forEach((e, index) => {
       const description = e.description.substr(0, 3) // 공휴일 or 기념일
       let bgStyle = description == '공휴일' ? 'holiday' : 'anniversary'
 
       state.items.push({
-        id: '1' + Math.random().toString(36).substring(2, 11), // gives an random id
+        id: 'h' + index + 1, // 공휴일은 고정 아이디 부여
         startDate: e.start.date,
         // endDate: e.end.date,  // 없어도 될 듯
         title: e.summary,
@@ -367,7 +367,10 @@ const clickTestAddItem = () => {
 }
 
 const onClickRequestBtn = () => {
-  router.push({ name: '휴가신청' })
+  router.push({
+    name: '휴가신청',
+    query: { items: JSON.stringify(state.items) },
+  })
 }
 </script>
 


### PR DESCRIPTION
1. 잔여 TO 계산 반영
2. 선택한 날짜에 잔여 TO가 0일 경우 경고 알림창 띄우고 신청하기 버튼 막음
3. 신청하기 버튼 기본 옵션 disabled로 수정해서 아무것도 선택하지 않았을 경우 신청 api 호출 못 하도록 제어
4. 잔여 TO가 0일 경우 해당 일자 배경 색을 얕은 그레이색으로 칠하도록 CSS 수정
5. 선택된 날짜들 중 이전 날짜가 있을 경우 신청하기 버튼 막음